### PR TITLE
Fix base64.b64encode() issue when using py3.x

### DIFF
--- a/custom-login/main.py
+++ b/custom-login/main.py
@@ -33,7 +33,7 @@ def login():
         'destination': oidc.extra_data_serializer.dumps(destination).decode('utf-8')
     }
 
-    return render_template("login.html", oidc=oidc, baseUri=bu, clientId=cid, state=base64.b64encode(json.dumps(state)))
+    return render_template("login.html", oidc=oidc, baseUri=bu, clientId=cid, state=base64_to_str(state))
 
 
 @app.route("/profile")
@@ -48,6 +48,10 @@ def logout():
     oidc.logout()
 
     return redirect(url_for("home"))
+
+
+def base64_to_str(data):
+    return str(base64.b64encode(json.dumps(data).encode('utf-8')), 'utf-8')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Resolved the following:

The base64.b64encode() method between py2.7 vs py3.x base64.b64encode() return typed has changed. In py2.7 it was `string` and now in py3.x it is `bytes`.

[py2.7 base64.b64encode](https://docs.python.org/2.7/library/base64.html#base64.b64encode)
vs
[py3.7 base64.b64encode](https://docs.python.org/3.7/library/base64.html#base64.b64encode)