### PR TITLE
Updated the Okta Widget to version 3.6

### DIFF
--- a/custom-login/templates/template.html
+++ b/custom-login/templates/template.html
@@ -9,11 +9,9 @@
     <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
 
-    <script src="https://ok1static.oktacdn.com/assets/js/sdk/okta-signin-widget/2.13.0/js/okta-sign-in.min.js"
+    <script src="https://global.oktacdn.com/okta-signin-widget/3.6.0/js/okta-sign-in.min.js"
             type="text/javascript"></script>
-    <link href="https://ok1static.oktacdn.com/assets/js/sdk/okta-signin-widget/2.13.0/css/okta-sign-in.min.css"
-          type="text/css" rel="stylesheet"/>
-    <link href="https://ok1static.oktacdn.com/assets/js/sdk/okta-signin-widget/2.13.0/css/okta-theme.css"
+    <link href="https://global.oktacdn.com/okta-signin-widget/3.6.0/css/okta-sign-in.min.css"
           type="text/css" rel="stylesheet"/>
     <style>
         body.login {


### PR DESCRIPTION
Obvious Fix - updated the Okta Widget to version 3.6. This allows developers to use the latest features of the Widget in the custom login sample.