### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ httplib2==0.11.3
 idna==2.7
 itsdangerous==0.24
 Jinja2==2.10
-MarkupSafe==1.0
+MarkupSafe==1.1.1
 oauth2client==4.1.3
 pyasn1==0.4.4
 pyasn1-modules==0.2.2


### PR DESCRIPTION
Changed from MarkupSafe==1.0 to MarkupSafe==1.1.1 to fix "ImportError: cannot import name Feature"
See https://github.com/pallets/markupsafe/issues/57