### PR TITLE
⚠️ Changed needed to allow the okta-hosted-login demo work (<=Python3.9)

### DIFF
--- a/okta-hosted-login/main.py
+++ b/okta-hosted-login/main.py
@@ -1,4 +1,6 @@
+import random
 import requests
+import string
 
 from flask import Flask, render_template, redirect, request, url_for
 from flask_login import (

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,9 @@
 requests==2.21.0
 Flask==1.0.2
 flask-cors==3.0.9
-pyOpenSSL==19.0.0
+pyOpenSSL==23.0.0
 Flask-Login==0.4.1
 okta-jwt-verifier==0.2.0
+itsdangerous==2.0.1
+jinja2==3.0.1
+Werkzeug~=2.0.0


### PR DESCRIPTION
I'm posting this in case it unsticks someone else. It will **not work in Python 3.10** so I used Python 3.9. 